### PR TITLE
Move Datalogger to proto3, slight format changes

### DIFF
--- a/datalogger/datalogger.proto
+++ b/datalogger/datalogger.proto
@@ -1,15 +1,15 @@
-syntax = "proto2";
+syntax = "proto3";
 
 import 'google/protobuf/timestamp.proto';
 import 'nanopb.proto';
 
 // Helper messages
 message StatisticalAggregate {
-  optional uint32 samples = 1;
-  optional int32 min = 2;
-  optional int32 max = 3;
-  optional int32 avg = 4;
-  optional uint32 stdev = 5;
+  uint32 samples = 1;
+  int32 min = 2;
+  int32 max = 3;
+  int32 avg = 4;
+  uint32 stdev = 5;
 }
 
 // Histogram with integer bucket boundaries and counts
@@ -24,10 +24,10 @@ message IntHistogram {
 
 // Actual messages
 message DataloggerRecord {
-  optional uint32 timestamp_ms = 1;
-  optional uint32 timestamp_variability = 2;
-  optional uint32 sourceId = 3;
-  optional DataloggerPayload payload = 4;
+  uint32 timestamp_ms = 1;
+  uint32 timestamp_variability = 2;
+  uint32 sourceId = 3;
+  DataloggerPayload payload = 4;
 }
 
 message DataloggerPayload {
@@ -37,12 +37,13 @@ message DataloggerPayload {
     CanMessage receivedCanMessage = 3;
     CanMessage transmittedCanMessage = 4;
     CanError canError = 5;
-    CanErrorCounter canErrorCount = 6;
-    StatisticalAggregate voltageReading = 7;
-    StatisticalAggregate temperatureReading = 8;
+    CanErrorCounter canErrorCount = 6 [deprecated=true];
+    StatisticalAggregate voltageReading = 7 [deprecated=true];
+    StatisticalAggregate temperatureReading = 8 [deprecated=true];
     StatisticalAggregate loopTimer = 9;
     IntHistogram loopTimerDistribution = 11;
     google.protobuf.Timestamp rtcTime = 10;
+    StatisticalAggregate sensorReading = 12;
   }
 }
 
@@ -54,27 +55,27 @@ message SourceDef {
     VOLTAGE = 3;
     TEMPERATURE = 4;
   }
-  optional SourceType sourceType = 1;
-  optional string name = 2 [(nanopb).max_size = 32];
+  SourceType sourceType = 1;
+  string name = 2 [(nanopb).max_size = 32];
 }
 
 message InfoString {
-  optional string info = 1 [(nanopb).max_size = 128];
+  string info = 1 [(nanopb).max_size = 128];
 }
 
 message CanMessage {
-  optional uint32 id = 1;
+  uint32 id = 1;
   enum FrameType {
     STANDARD_FRAME = 0;
     EXTENDED_FRAME = 1;
   }
-  optional FrameType length = 2;
+  FrameType length = 2;
   enum RtrType {
     DATA_FRAME = 0;
     REMOTE_FRAME = 1;
   }
-  optional RtrType rtr = 3;
-  optional bytes data = 4 [(nanopb).max_size = 8];
+  RtrType rtr = 3;
+  bytes data = 4 [(nanopb).max_size = 8];
 }
 
 message CanError {
@@ -87,7 +88,7 @@ message CanError {
     ARBITRATION_LOST = 5;
     OTHER = 127;
   }
-  optional ErrorSource source = 1;
+  ErrorSource source = 1;
 }
 
 message CanErrorCounter {
@@ -95,6 +96,6 @@ message CanErrorCounter {
     TRANSMIT_COUNTER = 0;
     RECEIVE_COUNTER = 1;
   }
-  optional ErrorCounterSource source = 1;
-  optional uint32 count = 2;
+  ErrorCounterSource source = 1;
+  uint32 count = 2;
 }

--- a/datalogger/datalogger.proto
+++ b/datalogger/datalogger.proto
@@ -40,10 +40,11 @@ message DataloggerPayload {
     CanErrorCounter canErrorCount = 6 [deprecated=true];
     StatisticalAggregate voltageReading = 7 [deprecated=true];
     StatisticalAggregate temperatureReading = 8 [deprecated=true];
-    StatisticalAggregate loopTimer = 9;
-    IntHistogram loopTimerDistribution = 11;
+    StatisticalAggregate loopTimer = 9 [deprecated=true];
+    IntHistogram loopTimerDistribution = 11 [deprecated=true];
     google.protobuf.Timestamp rtcTime = 10;
     StatisticalAggregate sensorReading = 12;
+    IntHistogram sensorDistribution = 13;
   }
 }
 

--- a/generated/datalogger/datalogger.pb.c
+++ b/generated/datalogger/datalogger.pb.c
@@ -33,7 +33,7 @@ const pb_field_t DataloggerRecord_fields[5] = {
     PB_LAST_FIELD
 };
 
-const pb_field_t DataloggerPayload_fields[13] = {
+const pb_field_t DataloggerPayload_fields[14] = {
     PB_ONEOF_FIELD(value,   1, MESSAGE , ONEOF, STATIC  , FIRST, DataloggerPayload, sourceDef, sourceDef, &SourceDef_fields),
     PB_ONEOF_FIELD(value,   2, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, info, info, &InfoString_fields),
     PB_ONEOF_FIELD(value,   3, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, receivedCanMessage, receivedCanMessage, &CanMessage_fields),
@@ -46,6 +46,7 @@ const pb_field_t DataloggerPayload_fields[13] = {
     PB_ONEOF_FIELD(value,  10, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, rtcTime, rtcTime, &google_protobuf_Timestamp_fields),
     PB_ONEOF_FIELD(value,  11, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, loopTimerDistribution, loopTimerDistribution, &IntHistogram_fields),
     PB_ONEOF_FIELD(value,  12, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, sensorReading, sensorReading, &StatisticalAggregate_fields),
+    PB_ONEOF_FIELD(value,  13, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, sensorDistribution, sensorDistribution, &IntHistogram_fields),
     PB_LAST_FIELD
 };
 
@@ -94,7 +95,7 @@ const pb_field_t CanErrorCounter_fields[3] = {
  * numbers or field sizes that are larger than what can fit in 8 or 16 bit
  * field descriptors.
  */
-PB_STATIC_ASSERT((pb_membersize(DataloggerRecord, payload) < 65536 && pb_membersize(DataloggerPayload, value.sourceDef) < 65536 && pb_membersize(DataloggerPayload, value.info) < 65536 && pb_membersize(DataloggerPayload, value.receivedCanMessage) < 65536 && pb_membersize(DataloggerPayload, value.transmittedCanMessage) < 65536 && pb_membersize(DataloggerPayload, value.canError) < 65536 && pb_membersize(DataloggerPayload, value.canErrorCount) < 65536 && pb_membersize(DataloggerPayload, value.voltageReading) < 65536 && pb_membersize(DataloggerPayload, value.temperatureReading) < 65536 && pb_membersize(DataloggerPayload, value.loopTimer) < 65536 && pb_membersize(DataloggerPayload, value.rtcTime) < 65536 && pb_membersize(DataloggerPayload, value.loopTimerDistribution) < 65536 && pb_membersize(DataloggerPayload, value.sensorReading) < 65536), YOU_MUST_DEFINE_PB_FIELD_32BIT_FOR_MESSAGES_StatisticalAggregate_IntHistogram_DataloggerRecord_DataloggerPayload_SourceDef_InfoString_CanMessage_CanError_CanErrorCounter)
+PB_STATIC_ASSERT((pb_membersize(DataloggerRecord, payload) < 65536 && pb_membersize(DataloggerPayload, value.sourceDef) < 65536 && pb_membersize(DataloggerPayload, value.info) < 65536 && pb_membersize(DataloggerPayload, value.receivedCanMessage) < 65536 && pb_membersize(DataloggerPayload, value.transmittedCanMessage) < 65536 && pb_membersize(DataloggerPayload, value.canError) < 65536 && pb_membersize(DataloggerPayload, value.canErrorCount) < 65536 && pb_membersize(DataloggerPayload, value.voltageReading) < 65536 && pb_membersize(DataloggerPayload, value.temperatureReading) < 65536 && pb_membersize(DataloggerPayload, value.loopTimer) < 65536 && pb_membersize(DataloggerPayload, value.rtcTime) < 65536 && pb_membersize(DataloggerPayload, value.loopTimerDistribution) < 65536 && pb_membersize(DataloggerPayload, value.sensorReading) < 65536 && pb_membersize(DataloggerPayload, value.sensorDistribution) < 65536), YOU_MUST_DEFINE_PB_FIELD_32BIT_FOR_MESSAGES_StatisticalAggregate_IntHistogram_DataloggerRecord_DataloggerPayload_SourceDef_InfoString_CanMessage_CanError_CanErrorCounter)
 #endif
 
 #if !defined(PB_FIELD_16BIT) && !defined(PB_FIELD_32BIT)
@@ -105,7 +106,7 @@ PB_STATIC_ASSERT((pb_membersize(DataloggerRecord, payload) < 65536 && pb_members
  * numbers or field sizes that are larger than what can fit in the default
  * 8 bit descriptors.
  */
-PB_STATIC_ASSERT((pb_membersize(DataloggerRecord, payload) < 256 && pb_membersize(DataloggerPayload, value.sourceDef) < 256 && pb_membersize(DataloggerPayload, value.info) < 256 && pb_membersize(DataloggerPayload, value.receivedCanMessage) < 256 && pb_membersize(DataloggerPayload, value.transmittedCanMessage) < 256 && pb_membersize(DataloggerPayload, value.canError) < 256 && pb_membersize(DataloggerPayload, value.canErrorCount) < 256 && pb_membersize(DataloggerPayload, value.voltageReading) < 256 && pb_membersize(DataloggerPayload, value.temperatureReading) < 256 && pb_membersize(DataloggerPayload, value.loopTimer) < 256 && pb_membersize(DataloggerPayload, value.rtcTime) < 256 && pb_membersize(DataloggerPayload, value.loopTimerDistribution) < 256 && pb_membersize(DataloggerPayload, value.sensorReading) < 256), YOU_MUST_DEFINE_PB_FIELD_16BIT_FOR_MESSAGES_StatisticalAggregate_IntHistogram_DataloggerRecord_DataloggerPayload_SourceDef_InfoString_CanMessage_CanError_CanErrorCounter)
+PB_STATIC_ASSERT((pb_membersize(DataloggerRecord, payload) < 256 && pb_membersize(DataloggerPayload, value.sourceDef) < 256 && pb_membersize(DataloggerPayload, value.info) < 256 && pb_membersize(DataloggerPayload, value.receivedCanMessage) < 256 && pb_membersize(DataloggerPayload, value.transmittedCanMessage) < 256 && pb_membersize(DataloggerPayload, value.canError) < 256 && pb_membersize(DataloggerPayload, value.canErrorCount) < 256 && pb_membersize(DataloggerPayload, value.voltageReading) < 256 && pb_membersize(DataloggerPayload, value.temperatureReading) < 256 && pb_membersize(DataloggerPayload, value.loopTimer) < 256 && pb_membersize(DataloggerPayload, value.rtcTime) < 256 && pb_membersize(DataloggerPayload, value.loopTimerDistribution) < 256 && pb_membersize(DataloggerPayload, value.sensorReading) < 256 && pb_membersize(DataloggerPayload, value.sensorDistribution) < 256), YOU_MUST_DEFINE_PB_FIELD_16BIT_FOR_MESSAGES_StatisticalAggregate_IntHistogram_DataloggerRecord_DataloggerPayload_SourceDef_InfoString_CanMessage_CanError_CanErrorCounter)
 #endif
 
 

--- a/generated/datalogger/datalogger.pb.c
+++ b/generated/datalogger/datalogger.pb.c
@@ -11,11 +11,11 @@
 
 
 const pb_field_t StatisticalAggregate_fields[6] = {
-    PB_FIELD(  1, UINT32  , OPTIONAL, STATIC  , FIRST, StatisticalAggregate, samples, samples, 0),
-    PB_FIELD(  2, INT32   , OPTIONAL, STATIC  , OTHER, StatisticalAggregate, min, samples, 0),
-    PB_FIELD(  3, INT32   , OPTIONAL, STATIC  , OTHER, StatisticalAggregate, max, min, 0),
-    PB_FIELD(  4, INT32   , OPTIONAL, STATIC  , OTHER, StatisticalAggregate, avg, max, 0),
-    PB_FIELD(  5, UINT32  , OPTIONAL, STATIC  , OTHER, StatisticalAggregate, stdev, avg, 0),
+    PB_FIELD(  1, UINT32  , SINGULAR, STATIC  , FIRST, StatisticalAggregate, samples, samples, 0),
+    PB_FIELD(  2, INT32   , SINGULAR, STATIC  , OTHER, StatisticalAggregate, min, samples, 0),
+    PB_FIELD(  3, INT32   , SINGULAR, STATIC  , OTHER, StatisticalAggregate, max, min, 0),
+    PB_FIELD(  4, INT32   , SINGULAR, STATIC  , OTHER, StatisticalAggregate, avg, max, 0),
+    PB_FIELD(  5, UINT32  , SINGULAR, STATIC  , OTHER, StatisticalAggregate, stdev, avg, 0),
     PB_LAST_FIELD
 };
 
@@ -26,14 +26,14 @@ const pb_field_t IntHistogram_fields[3] = {
 };
 
 const pb_field_t DataloggerRecord_fields[5] = {
-    PB_FIELD(  1, UINT32  , OPTIONAL, STATIC  , FIRST, DataloggerRecord, timestamp_ms, timestamp_ms, 0),
-    PB_FIELD(  2, UINT32  , OPTIONAL, STATIC  , OTHER, DataloggerRecord, timestamp_variability, timestamp_ms, 0),
-    PB_FIELD(  3, UINT32  , OPTIONAL, STATIC  , OTHER, DataloggerRecord, sourceId, timestamp_variability, 0),
-    PB_FIELD(  4, MESSAGE , OPTIONAL, STATIC  , OTHER, DataloggerRecord, payload, sourceId, &DataloggerPayload_fields),
+    PB_FIELD(  1, UINT32  , SINGULAR, STATIC  , FIRST, DataloggerRecord, timestamp_ms, timestamp_ms, 0),
+    PB_FIELD(  2, UINT32  , SINGULAR, STATIC  , OTHER, DataloggerRecord, timestamp_variability, timestamp_ms, 0),
+    PB_FIELD(  3, UINT32  , SINGULAR, STATIC  , OTHER, DataloggerRecord, sourceId, timestamp_variability, 0),
+    PB_FIELD(  4, MESSAGE , SINGULAR, STATIC  , OTHER, DataloggerRecord, payload, sourceId, &DataloggerPayload_fields),
     PB_LAST_FIELD
 };
 
-const pb_field_t DataloggerPayload_fields[12] = {
+const pb_field_t DataloggerPayload_fields[13] = {
     PB_ONEOF_FIELD(value,   1, MESSAGE , ONEOF, STATIC  , FIRST, DataloggerPayload, sourceDef, sourceDef, &SourceDef_fields),
     PB_ONEOF_FIELD(value,   2, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, info, info, &InfoString_fields),
     PB_ONEOF_FIELD(value,   3, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, receivedCanMessage, receivedCanMessage, &CanMessage_fields),
@@ -45,36 +45,37 @@ const pb_field_t DataloggerPayload_fields[12] = {
     PB_ONEOF_FIELD(value,   9, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, loopTimer, loopTimer, &StatisticalAggregate_fields),
     PB_ONEOF_FIELD(value,  10, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, rtcTime, rtcTime, &google_protobuf_Timestamp_fields),
     PB_ONEOF_FIELD(value,  11, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, loopTimerDistribution, loopTimerDistribution, &IntHistogram_fields),
+    PB_ONEOF_FIELD(value,  12, MESSAGE , ONEOF, STATIC  , UNION, DataloggerPayload, sensorReading, sensorReading, &StatisticalAggregate_fields),
     PB_LAST_FIELD
 };
 
 const pb_field_t SourceDef_fields[3] = {
-    PB_FIELD(  1, UENUM   , OPTIONAL, STATIC  , FIRST, SourceDef, sourceType, sourceType, 0),
-    PB_FIELD(  2, STRING  , OPTIONAL, STATIC  , OTHER, SourceDef, name, sourceType, 0),
+    PB_FIELD(  1, UENUM   , SINGULAR, STATIC  , FIRST, SourceDef, sourceType, sourceType, 0),
+    PB_FIELD(  2, STRING  , SINGULAR, STATIC  , OTHER, SourceDef, name, sourceType, 0),
     PB_LAST_FIELD
 };
 
 const pb_field_t InfoString_fields[2] = {
-    PB_FIELD(  1, STRING  , OPTIONAL, STATIC  , FIRST, InfoString, info, info, 0),
+    PB_FIELD(  1, STRING  , SINGULAR, STATIC  , FIRST, InfoString, info, info, 0),
     PB_LAST_FIELD
 };
 
 const pb_field_t CanMessage_fields[5] = {
-    PB_FIELD(  1, UINT32  , OPTIONAL, STATIC  , FIRST, CanMessage, id, id, 0),
-    PB_FIELD(  2, UENUM   , OPTIONAL, STATIC  , OTHER, CanMessage, length, id, 0),
-    PB_FIELD(  3, UENUM   , OPTIONAL, STATIC  , OTHER, CanMessage, rtr, length, 0),
-    PB_FIELD(  4, BYTES   , OPTIONAL, STATIC  , OTHER, CanMessage, data, rtr, 0),
+    PB_FIELD(  1, UINT32  , SINGULAR, STATIC  , FIRST, CanMessage, id, id, 0),
+    PB_FIELD(  2, UENUM   , SINGULAR, STATIC  , OTHER, CanMessage, length, id, 0),
+    PB_FIELD(  3, UENUM   , SINGULAR, STATIC  , OTHER, CanMessage, rtr, length, 0),
+    PB_FIELD(  4, BYTES   , SINGULAR, STATIC  , OTHER, CanMessage, data, rtr, 0),
     PB_LAST_FIELD
 };
 
 const pb_field_t CanError_fields[2] = {
-    PB_FIELD(  1, UENUM   , OPTIONAL, STATIC  , FIRST, CanError, source, source, 0),
+    PB_FIELD(  1, UENUM   , SINGULAR, STATIC  , FIRST, CanError, source, source, 0),
     PB_LAST_FIELD
 };
 
 const pb_field_t CanErrorCounter_fields[3] = {
-    PB_FIELD(  1, UENUM   , OPTIONAL, STATIC  , FIRST, CanErrorCounter, source, source, 0),
-    PB_FIELD(  2, UINT32  , OPTIONAL, STATIC  , OTHER, CanErrorCounter, count, source, 0),
+    PB_FIELD(  1, UENUM   , SINGULAR, STATIC  , FIRST, CanErrorCounter, source, source, 0),
+    PB_FIELD(  2, UINT32  , SINGULAR, STATIC  , OTHER, CanErrorCounter, count, source, 0),
     PB_LAST_FIELD
 };
 
@@ -93,7 +94,7 @@ const pb_field_t CanErrorCounter_fields[3] = {
  * numbers or field sizes that are larger than what can fit in 8 or 16 bit
  * field descriptors.
  */
-PB_STATIC_ASSERT((pb_membersize(DataloggerRecord, payload) < 65536 && pb_membersize(DataloggerPayload, value.sourceDef) < 65536 && pb_membersize(DataloggerPayload, value.info) < 65536 && pb_membersize(DataloggerPayload, value.receivedCanMessage) < 65536 && pb_membersize(DataloggerPayload, value.transmittedCanMessage) < 65536 && pb_membersize(DataloggerPayload, value.canError) < 65536 && pb_membersize(DataloggerPayload, value.canErrorCount) < 65536 && pb_membersize(DataloggerPayload, value.voltageReading) < 65536 && pb_membersize(DataloggerPayload, value.temperatureReading) < 65536 && pb_membersize(DataloggerPayload, value.loopTimer) < 65536 && pb_membersize(DataloggerPayload, value.rtcTime) < 65536 && pb_membersize(DataloggerPayload, value.loopTimerDistribution) < 65536), YOU_MUST_DEFINE_PB_FIELD_32BIT_FOR_MESSAGES_StatisticalAggregate_IntHistogram_DataloggerRecord_DataloggerPayload_SourceDef_InfoString_CanMessage_CanError_CanErrorCounter)
+PB_STATIC_ASSERT((pb_membersize(DataloggerRecord, payload) < 65536 && pb_membersize(DataloggerPayload, value.sourceDef) < 65536 && pb_membersize(DataloggerPayload, value.info) < 65536 && pb_membersize(DataloggerPayload, value.receivedCanMessage) < 65536 && pb_membersize(DataloggerPayload, value.transmittedCanMessage) < 65536 && pb_membersize(DataloggerPayload, value.canError) < 65536 && pb_membersize(DataloggerPayload, value.canErrorCount) < 65536 && pb_membersize(DataloggerPayload, value.voltageReading) < 65536 && pb_membersize(DataloggerPayload, value.temperatureReading) < 65536 && pb_membersize(DataloggerPayload, value.loopTimer) < 65536 && pb_membersize(DataloggerPayload, value.rtcTime) < 65536 && pb_membersize(DataloggerPayload, value.loopTimerDistribution) < 65536 && pb_membersize(DataloggerPayload, value.sensorReading) < 65536), YOU_MUST_DEFINE_PB_FIELD_32BIT_FOR_MESSAGES_StatisticalAggregate_IntHistogram_DataloggerRecord_DataloggerPayload_SourceDef_InfoString_CanMessage_CanError_CanErrorCounter)
 #endif
 
 #if !defined(PB_FIELD_16BIT) && !defined(PB_FIELD_32BIT)
@@ -104,7 +105,7 @@ PB_STATIC_ASSERT((pb_membersize(DataloggerRecord, payload) < 65536 && pb_members
  * numbers or field sizes that are larger than what can fit in the default
  * 8 bit descriptors.
  */
-PB_STATIC_ASSERT((pb_membersize(DataloggerRecord, payload) < 256 && pb_membersize(DataloggerPayload, value.sourceDef) < 256 && pb_membersize(DataloggerPayload, value.info) < 256 && pb_membersize(DataloggerPayload, value.receivedCanMessage) < 256 && pb_membersize(DataloggerPayload, value.transmittedCanMessage) < 256 && pb_membersize(DataloggerPayload, value.canError) < 256 && pb_membersize(DataloggerPayload, value.canErrorCount) < 256 && pb_membersize(DataloggerPayload, value.voltageReading) < 256 && pb_membersize(DataloggerPayload, value.temperatureReading) < 256 && pb_membersize(DataloggerPayload, value.loopTimer) < 256 && pb_membersize(DataloggerPayload, value.rtcTime) < 256 && pb_membersize(DataloggerPayload, value.loopTimerDistribution) < 256), YOU_MUST_DEFINE_PB_FIELD_16BIT_FOR_MESSAGES_StatisticalAggregate_IntHistogram_DataloggerRecord_DataloggerPayload_SourceDef_InfoString_CanMessage_CanError_CanErrorCounter)
+PB_STATIC_ASSERT((pb_membersize(DataloggerRecord, payload) < 256 && pb_membersize(DataloggerPayload, value.sourceDef) < 256 && pb_membersize(DataloggerPayload, value.info) < 256 && pb_membersize(DataloggerPayload, value.receivedCanMessage) < 256 && pb_membersize(DataloggerPayload, value.transmittedCanMessage) < 256 && pb_membersize(DataloggerPayload, value.canError) < 256 && pb_membersize(DataloggerPayload, value.canErrorCount) < 256 && pb_membersize(DataloggerPayload, value.voltageReading) < 256 && pb_membersize(DataloggerPayload, value.temperatureReading) < 256 && pb_membersize(DataloggerPayload, value.loopTimer) < 256 && pb_membersize(DataloggerPayload, value.rtcTime) < 256 && pb_membersize(DataloggerPayload, value.loopTimerDistribution) < 256 && pb_membersize(DataloggerPayload, value.sensorReading) < 256), YOU_MUST_DEFINE_PB_FIELD_16BIT_FOR_MESSAGES_StatisticalAggregate_IntHistogram_DataloggerRecord_DataloggerPayload_SourceDef_InfoString_CanMessage_CanError_CanErrorCounter)
 #endif
 
 

--- a/generated/datalogger/datalogger.pb.h
+++ b/generated/datalogger/datalogger.pb.h
@@ -129,6 +129,7 @@ typedef struct _DataloggerPayload {
         google_protobuf_Timestamp rtcTime;
         IntHistogram loopTimerDistribution;
         StatisticalAggregate sensorReading;
+        IntHistogram sensorDistribution;
     } value;
 /* @@protoc_insertion_point(struct:DataloggerPayload) */
 } DataloggerPayload;
@@ -193,6 +194,7 @@ typedef struct _DataloggerRecord {
 #define DataloggerPayload_rtcTime_tag            10
 #define DataloggerPayload_loopTimerDistribution_tag 11
 #define DataloggerPayload_sensorReading_tag      12
+#define DataloggerPayload_sensorDistribution_tag 13
 #define DataloggerRecord_timestamp_ms_tag        1
 #define DataloggerRecord_timestamp_variability_tag 2
 #define DataloggerRecord_sourceId_tag            3
@@ -202,7 +204,7 @@ typedef struct _DataloggerRecord {
 extern const pb_field_t StatisticalAggregate_fields[6];
 extern const pb_field_t IntHistogram_fields[3];
 extern const pb_field_t DataloggerRecord_fields[5];
-extern const pb_field_t DataloggerPayload_fields[13];
+extern const pb_field_t DataloggerPayload_fields[14];
 extern const pb_field_t SourceDef_fields[3];
 extern const pb_field_t InfoString_fields[2];
 extern const pb_field_t CanMessage_fields[5];

--- a/generated/datalogger/datalogger.pb.h
+++ b/generated/datalogger/datalogger.pb.h
@@ -67,34 +67,26 @@ typedef enum _CanErrorCounter_ErrorCounterSource {
 
 /* Struct definitions */
 typedef struct _CanError {
-    bool has_source;
     CanError_ErrorSource source;
 /* @@protoc_insertion_point(struct:CanError) */
 } CanError;
 
 typedef struct _CanErrorCounter {
-    bool has_source;
     CanErrorCounter_ErrorCounterSource source;
-    bool has_count;
     uint32_t count;
 /* @@protoc_insertion_point(struct:CanErrorCounter) */
 } CanErrorCounter;
 
 typedef PB_BYTES_ARRAY_T(8) CanMessage_data_t;
 typedef struct _CanMessage {
-    bool has_id;
     uint32_t id;
-    bool has_length;
     CanMessage_FrameType length;
-    bool has_rtr;
     CanMessage_RtrType rtr;
-    bool has_data;
     CanMessage_data_t data;
 /* @@protoc_insertion_point(struct:CanMessage) */
 } CanMessage;
 
 typedef struct _InfoString {
-    bool has_info;
     char info[128];
 /* @@protoc_insertion_point(struct:InfoString) */
 } InfoString;
@@ -108,23 +100,16 @@ typedef struct _IntHistogram {
 } IntHistogram;
 
 typedef struct _SourceDef {
-    bool has_sourceType;
     SourceDef_SourceType sourceType;
-    bool has_name;
     char name[32];
 /* @@protoc_insertion_point(struct:SourceDef) */
 } SourceDef;
 
 typedef struct _StatisticalAggregate {
-    bool has_samples;
     uint32_t samples;
-    bool has_min;
     int32_t min;
-    bool has_max;
     int32_t max;
-    bool has_avg;
     int32_t avg;
-    bool has_stdev;
     uint32_t stdev;
 /* @@protoc_insertion_point(struct:StatisticalAggregate) */
 } StatisticalAggregate;
@@ -143,18 +128,15 @@ typedef struct _DataloggerPayload {
         StatisticalAggregate loopTimer;
         google_protobuf_Timestamp rtcTime;
         IntHistogram loopTimerDistribution;
+        StatisticalAggregate sensorReading;
     } value;
 /* @@protoc_insertion_point(struct:DataloggerPayload) */
 } DataloggerPayload;
 
 typedef struct _DataloggerRecord {
-    bool has_timestamp_ms;
     uint32_t timestamp_ms;
-    bool has_timestamp_variability;
     uint32_t timestamp_variability;
-    bool has_sourceId;
     uint32_t sourceId;
-    bool has_payload;
     DataloggerPayload payload;
 /* @@protoc_insertion_point(struct:DataloggerRecord) */
 } DataloggerRecord;
@@ -162,24 +144,24 @@ typedef struct _DataloggerRecord {
 /* Default values for struct fields */
 
 /* Initializer values for message structs */
-#define StatisticalAggregate_init_default        {false, 0, false, 0, false, 0, false, 0, false, 0}
+#define StatisticalAggregate_init_default        {0, 0, 0, 0, 0}
 #define IntHistogram_init_default                {0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}
-#define DataloggerRecord_init_default            {false, 0, false, 0, false, 0, false, DataloggerPayload_init_default}
+#define DataloggerRecord_init_default            {0, 0, 0, DataloggerPayload_init_default}
 #define DataloggerPayload_init_default           {0, {SourceDef_init_default}}
-#define SourceDef_init_default                   {false, (SourceDef_SourceType)0, false, ""}
-#define InfoString_init_default                  {false, ""}
-#define CanMessage_init_default                  {false, 0, false, (CanMessage_FrameType)0, false, (CanMessage_RtrType)0, false, {0, {0}}}
-#define CanError_init_default                    {false, (CanError_ErrorSource)0}
-#define CanErrorCounter_init_default             {false, (CanErrorCounter_ErrorCounterSource)0, false, 0}
-#define StatisticalAggregate_init_zero           {false, 0, false, 0, false, 0, false, 0, false, 0}
+#define SourceDef_init_default                   {(SourceDef_SourceType)0, ""}
+#define InfoString_init_default                  {""}
+#define CanMessage_init_default                  {0, (CanMessage_FrameType)0, (CanMessage_RtrType)0, {0, {0}}}
+#define CanError_init_default                    {(CanError_ErrorSource)0}
+#define CanErrorCounter_init_default             {(CanErrorCounter_ErrorCounterSource)0, 0}
+#define StatisticalAggregate_init_zero           {0, 0, 0, 0, 0}
 #define IntHistogram_init_zero                   {0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}
-#define DataloggerRecord_init_zero               {false, 0, false, 0, false, 0, false, DataloggerPayload_init_zero}
+#define DataloggerRecord_init_zero               {0, 0, 0, DataloggerPayload_init_zero}
 #define DataloggerPayload_init_zero              {0, {SourceDef_init_zero}}
-#define SourceDef_init_zero                      {false, (SourceDef_SourceType)0, false, ""}
-#define InfoString_init_zero                     {false, ""}
-#define CanMessage_init_zero                     {false, 0, false, (CanMessage_FrameType)0, false, (CanMessage_RtrType)0, false, {0, {0}}}
-#define CanError_init_zero                       {false, (CanError_ErrorSource)0}
-#define CanErrorCounter_init_zero                {false, (CanErrorCounter_ErrorCounterSource)0, false, 0}
+#define SourceDef_init_zero                      {(SourceDef_SourceType)0, ""}
+#define InfoString_init_zero                     {""}
+#define CanMessage_init_zero                     {0, (CanMessage_FrameType)0, (CanMessage_RtrType)0, {0, {0}}}
+#define CanError_init_zero                       {(CanError_ErrorSource)0}
+#define CanErrorCounter_init_zero                {(CanErrorCounter_ErrorCounterSource)0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define CanError_source_tag                      1
@@ -210,6 +192,7 @@ typedef struct _DataloggerRecord {
 #define DataloggerPayload_loopTimer_tag          9
 #define DataloggerPayload_rtcTime_tag            10
 #define DataloggerPayload_loopTimerDistribution_tag 11
+#define DataloggerPayload_sensorReading_tag      12
 #define DataloggerRecord_timestamp_ms_tag        1
 #define DataloggerRecord_timestamp_variability_tag 2
 #define DataloggerRecord_sourceId_tag            3
@@ -219,7 +202,7 @@ typedef struct _DataloggerRecord {
 extern const pb_field_t StatisticalAggregate_fields[6];
 extern const pb_field_t IntHistogram_fields[3];
 extern const pb_field_t DataloggerRecord_fields[5];
-extern const pb_field_t DataloggerPayload_fields[12];
+extern const pb_field_t DataloggerPayload_fields[13];
 extern const pb_field_t SourceDef_fields[3];
 extern const pb_field_t InfoString_fields[2];
 extern const pb_field_t CanMessage_fields[5];

--- a/generated/datalogger/datalogger_pb2.py
+++ b/generated/datalogger/datalogger_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='datalogger.proto',
   package='',
   syntax='proto3',
-  serialized_pb=_b('\n\x10\x64\x61talogger.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x0cnanopb.proto\"]\n\x14StatisticalAggregate\x12\x0f\n\x07samples\x18\x01 \x01(\r\x12\x0b\n\x03min\x18\x02 \x01(\x05\x12\x0b\n\x03max\x18\x03 \x01(\x05\x12\x0b\n\x03\x61vg\x18\x04 \x01(\x05\x12\r\n\x05stdev\x18\x05 \x01(\r\"=\n\x0cIntHistogram\x12\x16\n\x07\x62uckets\x18\x01 \x03(\x05\x42\x05\x92?\x02\x10\n\x12\x15\n\x06\x63ounts\x18\x02 \x03(\rB\x05\x92?\x02\x10\x0b\"\x82\x01\n\x10\x44\x61taloggerRecord\x12\x14\n\x0ctimestamp_ms\x18\x01 \x01(\r\x12!\n\x15timestamp_variability\x18\x02 \x01(\rB\x02\x18\x01\x12\x10\n\x08sourceId\x18\x03 \x01(\r\x12#\n\x07payload\x18\x04 \x01(\x0b\x32\x12.DataloggerPayload\"\xa6\x04\n\x11\x44\x61taloggerPayload\x12\x1f\n\tsourceDef\x18\x01 \x01(\x0b\x32\n.SourceDefH\x00\x12\x1b\n\x04info\x18\x02 \x01(\x0b\x32\x0b.InfoStringH\x00\x12)\n\x12receivedCanMessage\x18\x03 \x01(\x0b\x32\x0b.CanMessageH\x00\x12,\n\x15transmittedCanMessage\x18\x04 \x01(\x0b\x32\x0b.CanMessageH\x00\x12\x1d\n\x08\x63\x61nError\x18\x05 \x01(\x0b\x32\t.CanErrorH\x00\x12)\n\rcanErrorCount\x18\x06 \x01(\x0b\x32\x10.CanErrorCounterH\x00\x12\x33\n\x0evoltageReading\x18\x07 \x01(\x0b\x32\x15.StatisticalAggregateB\x02\x18\x01H\x00\x12\x37\n\x12temperatureReading\x18\x08 \x01(\x0b\x32\x15.StatisticalAggregateB\x02\x18\x01H\x00\x12*\n\tloopTimer\x18\t \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x12.\n\x15loopTimerDistribution\x18\x0b \x01(\x0b\x32\r.IntHistogramH\x00\x12-\n\x07rtcTime\x18\n \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00\x12.\n\rsensorReading\x18\x0c \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x42\x07\n\x05value\"\x97\x01\n\tSourceDef\x12)\n\nsourceType\x18\x01 \x01(\x0e\x32\x15.SourceDef.SourceType\x12\x13\n\x04name\x18\x02 \x01(\tB\x05\x92?\x02\x08 \"J\n\nSourceType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x07\n\x03\x43\x41N\x10\x01\x12\x08\n\x04TIME\x10\x02\x12\x0b\n\x07VOLTAGE\x10\x03\x12\x0f\n\x0bTEMPERATURE\x10\x04\"\"\n\nInfoString\x12\x14\n\x04info\x18\x01 \x01(\tB\x06\x92?\x03\x08\x80\x01\"\xd8\x01\n\nCanMessage\x12\n\n\x02id\x18\x01 \x01(\r\x12%\n\x06length\x18\x02 \x01(\x0e\x32\x15.CanMessage.FrameType\x12 \n\x03rtr\x18\x03 \x01(\x0e\x32\x13.CanMessage.RtrType\x12\x13\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x42\x05\x92?\x02\x08\x08\"3\n\tFrameType\x12\x12\n\x0eSTANDARD_FRAME\x10\x00\x12\x12\n\x0e\x45XTENDED_FRAME\x10\x01\"+\n\x07RtrType\x12\x0e\n\nDATA_FRAME\x10\x00\x12\x10\n\x0cREMOTE_FRAME\x10\x01\"\xb4\x01\n\x08\x43\x61nError\x12%\n\x06source\x18\x01 \x01(\x0e\x32\x15.CanError.ErrorSource\"\x80\x01\n\x0b\x45rrorSource\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x11\n\rERROR_WARNING\x10\x01\x12\x11\n\rERROR_PASSIVE\x10\x02\x12\x0b\n\x07\x42US_OFF\x10\x03\x12\x10\n\x0c\x44\x41TA_OVERRUN\x10\x04\x12\x14\n\x10\x41RBITRATION_LOST\x10\x05\x12\t\n\x05OTHER\x10\x7f\"\x96\x01\n\x0f\x43\x61nErrorCounter\x12\x33\n\x06source\x18\x01 \x01(\x0e\x32#.CanErrorCounter.ErrorCounterSource\x12\r\n\x05\x63ount\x18\x02 \x01(\r\"?\n\x12\x45rrorCounterSource\x12\x14\n\x10TRANSMIT_COUNTER\x10\x00\x12\x13\n\x0fRECEIVE_COUNTER\x10\x01\x62\x06proto3')
+  serialized_pb=_b('\n\x10\x64\x61talogger.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x0cnanopb.proto\"]\n\x14StatisticalAggregate\x12\x0f\n\x07samples\x18\x01 \x01(\r\x12\x0b\n\x03min\x18\x02 \x01(\x05\x12\x0b\n\x03max\x18\x03 \x01(\x05\x12\x0b\n\x03\x61vg\x18\x04 \x01(\x05\x12\r\n\x05stdev\x18\x05 \x01(\r\"=\n\x0cIntHistogram\x12\x16\n\x07\x62uckets\x18\x01 \x03(\x05\x42\x05\x92?\x02\x10\n\x12\x15\n\x06\x63ounts\x18\x02 \x03(\rB\x05\x92?\x02\x10\x0b\"~\n\x10\x44\x61taloggerRecord\x12\x14\n\x0ctimestamp_ms\x18\x01 \x01(\r\x12\x1d\n\x15timestamp_variability\x18\x02 \x01(\r\x12\x10\n\x08sourceId\x18\x03 \x01(\r\x12#\n\x07payload\x18\x04 \x01(\x0b\x32\x12.DataloggerPayload\"\xaa\x04\n\x11\x44\x61taloggerPayload\x12\x1f\n\tsourceDef\x18\x01 \x01(\x0b\x32\n.SourceDefH\x00\x12\x1b\n\x04info\x18\x02 \x01(\x0b\x32\x0b.InfoStringH\x00\x12)\n\x12receivedCanMessage\x18\x03 \x01(\x0b\x32\x0b.CanMessageH\x00\x12,\n\x15transmittedCanMessage\x18\x04 \x01(\x0b\x32\x0b.CanMessageH\x00\x12\x1d\n\x08\x63\x61nError\x18\x05 \x01(\x0b\x32\t.CanErrorH\x00\x12-\n\rcanErrorCount\x18\x06 \x01(\x0b\x32\x10.CanErrorCounterB\x02\x18\x01H\x00\x12\x33\n\x0evoltageReading\x18\x07 \x01(\x0b\x32\x15.StatisticalAggregateB\x02\x18\x01H\x00\x12\x37\n\x12temperatureReading\x18\x08 \x01(\x0b\x32\x15.StatisticalAggregateB\x02\x18\x01H\x00\x12*\n\tloopTimer\x18\t \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x12.\n\x15loopTimerDistribution\x18\x0b \x01(\x0b\x32\r.IntHistogramH\x00\x12-\n\x07rtcTime\x18\n \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00\x12.\n\rsensorReading\x18\x0c \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x42\x07\n\x05value\"\x97\x01\n\tSourceDef\x12)\n\nsourceType\x18\x01 \x01(\x0e\x32\x15.SourceDef.SourceType\x12\x13\n\x04name\x18\x02 \x01(\tB\x05\x92?\x02\x08 \"J\n\nSourceType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x07\n\x03\x43\x41N\x10\x01\x12\x08\n\x04TIME\x10\x02\x12\x0b\n\x07VOLTAGE\x10\x03\x12\x0f\n\x0bTEMPERATURE\x10\x04\"\"\n\nInfoString\x12\x14\n\x04info\x18\x01 \x01(\tB\x06\x92?\x03\x08\x80\x01\"\xd8\x01\n\nCanMessage\x12\n\n\x02id\x18\x01 \x01(\r\x12%\n\x06length\x18\x02 \x01(\x0e\x32\x15.CanMessage.FrameType\x12 \n\x03rtr\x18\x03 \x01(\x0e\x32\x13.CanMessage.RtrType\x12\x13\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x42\x05\x92?\x02\x08\x08\"3\n\tFrameType\x12\x12\n\x0eSTANDARD_FRAME\x10\x00\x12\x12\n\x0e\x45XTENDED_FRAME\x10\x01\"+\n\x07RtrType\x12\x0e\n\nDATA_FRAME\x10\x00\x12\x10\n\x0cREMOTE_FRAME\x10\x01\"\xb4\x01\n\x08\x43\x61nError\x12%\n\x06source\x18\x01 \x01(\x0e\x32\x15.CanError.ErrorSource\"\x80\x01\n\x0b\x45rrorSource\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x11\n\rERROR_WARNING\x10\x01\x12\x11\n\rERROR_PASSIVE\x10\x02\x12\x0b\n\x07\x42US_OFF\x10\x03\x12\x10\n\x0c\x44\x41TA_OVERRUN\x10\x04\x12\x14\n\x10\x41RBITRATION_LOST\x10\x05\x12\t\n\x05OTHER\x10\x7f\"\x96\x01\n\x0f\x43\x61nErrorCounter\x12\x33\n\x06source\x18\x01 \x01(\x0e\x32#.CanErrorCounter.ErrorCounterSource\x12\r\n\x05\x63ount\x18\x02 \x01(\r\"?\n\x12\x45rrorCounterSource\x12\x14\n\x10TRANSMIT_COUNTER\x10\x00\x12\x13\n\x0fRECEIVE_COUNTER\x10\x01\x62\x06proto3')
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,nanopb__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -57,8 +57,8 @@ _SOURCEDEF_SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=989,
-  serialized_end=1063,
+  serialized_start=988,
+  serialized_end=1062,
 )
 _sym_db.RegisterEnumDescriptor(_SOURCEDEF_SOURCETYPE)
 
@@ -79,8 +79,8 @@ _CANMESSAGE_FRAMETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1222,
-  serialized_end=1273,
+  serialized_start=1221,
+  serialized_end=1272,
 )
 _sym_db.RegisterEnumDescriptor(_CANMESSAGE_FRAMETYPE)
 
@@ -101,8 +101,8 @@ _CANMESSAGE_RTRTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1275,
-  serialized_end=1318,
+  serialized_start=1274,
+  serialized_end=1317,
 )
 _sym_db.RegisterEnumDescriptor(_CANMESSAGE_RTRTYPE)
 
@@ -143,8 +143,8 @@ _CANERROR_ERRORSOURCE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1373,
-  serialized_end=1501,
+  serialized_start=1372,
+  serialized_end=1500,
 )
 _sym_db.RegisterEnumDescriptor(_CANERROR_ERRORSOURCE)
 
@@ -165,8 +165,8 @@ _CANERRORCOUNTER_ERRORCOUNTERSOURCE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1591,
-  serialized_end=1654,
+  serialized_start=1590,
+  serialized_end=1653,
 )
 _sym_db.RegisterEnumDescriptor(_CANERRORCOUNTER_ERRORCOUNTERSOURCE)
 
@@ -288,7 +288,7 @@ _DATALOGGERRECORD = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))),
+      options=None),
     _descriptor.FieldDescriptor(
       name='sourceId', full_name='DataloggerRecord.sourceId', index=2,
       number=3, type=13, cpp_type=3, label=1,
@@ -315,8 +315,8 @@ _DATALOGGERRECORD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=226,
-  serialized_end=356,
+  serialized_start=225,
+  serialized_end=351,
 )
 
 
@@ -368,7 +368,7 @@ _DATALOGGERPAYLOAD = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))),
     _descriptor.FieldDescriptor(
       name='voltageReading', full_name='DataloggerPayload.voltageReading', index=6,
       number=7, type=11, cpp_type=10, label=1,
@@ -426,8 +426,8 @@ _DATALOGGERPAYLOAD = _descriptor.Descriptor(
       name='value', full_name='DataloggerPayload.value',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=359,
-  serialized_end=909,
+  serialized_start=354,
+  serialized_end=908,
 )
 
 
@@ -465,8 +465,8 @@ _SOURCEDEF = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=912,
-  serialized_end=1063,
+  serialized_start=911,
+  serialized_end=1062,
 )
 
 
@@ -496,8 +496,8 @@ _INFOSTRING = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1065,
-  serialized_end=1099,
+  serialized_start=1064,
+  serialized_end=1098,
 )
 
 
@@ -550,8 +550,8 @@ _CANMESSAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1102,
-  serialized_end=1318,
+  serialized_start=1101,
+  serialized_end=1317,
 )
 
 
@@ -582,8 +582,8 @@ _CANERROR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1321,
-  serialized_end=1501,
+  serialized_start=1320,
+  serialized_end=1500,
 )
 
 
@@ -621,8 +621,8 @@ _CANERRORCOUNTER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1504,
-  serialized_end=1654,
+  serialized_start=1503,
+  serialized_end=1653,
 )
 
 _DATALOGGERRECORD.fields_by_name['payload'].message_type = _DATALOGGERPAYLOAD
@@ -762,8 +762,8 @@ _INTHISTOGRAM.fields_by_name['buckets'].has_options = True
 _INTHISTOGRAM.fields_by_name['buckets']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\222?\002\020\n'))
 _INTHISTOGRAM.fields_by_name['counts'].has_options = True
 _INTHISTOGRAM.fields_by_name['counts']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\222?\002\020\013'))
-_DATALOGGERRECORD.fields_by_name['timestamp_variability'].has_options = True
-_DATALOGGERRECORD.fields_by_name['timestamp_variability']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
+_DATALOGGERPAYLOAD.fields_by_name['canErrorCount'].has_options = True
+_DATALOGGERPAYLOAD.fields_by_name['canErrorCount']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
 _DATALOGGERPAYLOAD.fields_by_name['voltageReading'].has_options = True
 _DATALOGGERPAYLOAD.fields_by_name['voltageReading']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
 _DATALOGGERPAYLOAD.fields_by_name['temperatureReading'].has_options = True

--- a/generated/datalogger/datalogger_pb2.py
+++ b/generated/datalogger/datalogger_pb2.py
@@ -20,8 +20,8 @@ import nanopb_pb2 as nanopb__pb2
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='datalogger.proto',
   package='',
-  syntax='proto2',
-  serialized_pb=_b('\n\x10\x64\x61talogger.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x0cnanopb.proto\"]\n\x14StatisticalAggregate\x12\x0f\n\x07samples\x18\x01 \x01(\r\x12\x0b\n\x03min\x18\x02 \x01(\x05\x12\x0b\n\x03max\x18\x03 \x01(\x05\x12\x0b\n\x03\x61vg\x18\x04 \x01(\x05\x12\r\n\x05stdev\x18\x05 \x01(\r\"=\n\x0cIntHistogram\x12\x16\n\x07\x62uckets\x18\x01 \x03(\x05\x42\x05\x92?\x02\x10\n\x12\x15\n\x06\x63ounts\x18\x02 \x03(\rB\x05\x92?\x02\x10\x0b\"~\n\x10\x44\x61taloggerRecord\x12\x14\n\x0ctimestamp_ms\x18\x01 \x01(\r\x12\x1d\n\x15timestamp_variability\x18\x02 \x01(\r\x12\x10\n\x08sourceId\x18\x03 \x01(\r\x12#\n\x07payload\x18\x04 \x01(\x0b\x32\x12.DataloggerPayload\"\xee\x03\n\x11\x44\x61taloggerPayload\x12\x1f\n\tsourceDef\x18\x01 \x01(\x0b\x32\n.SourceDefH\x00\x12\x1b\n\x04info\x18\x02 \x01(\x0b\x32\x0b.InfoStringH\x00\x12)\n\x12receivedCanMessage\x18\x03 \x01(\x0b\x32\x0b.CanMessageH\x00\x12,\n\x15transmittedCanMessage\x18\x04 \x01(\x0b\x32\x0b.CanMessageH\x00\x12\x1d\n\x08\x63\x61nError\x18\x05 \x01(\x0b\x32\t.CanErrorH\x00\x12)\n\rcanErrorCount\x18\x06 \x01(\x0b\x32\x10.CanErrorCounterH\x00\x12/\n\x0evoltageReading\x18\x07 \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x12\x33\n\x12temperatureReading\x18\x08 \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x12*\n\tloopTimer\x18\t \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x12.\n\x15loopTimerDistribution\x18\x0b \x01(\x0b\x32\r.IntHistogramH\x00\x12-\n\x07rtcTime\x18\n \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00\x42\x07\n\x05value\"\x97\x01\n\tSourceDef\x12)\n\nsourceType\x18\x01 \x01(\x0e\x32\x15.SourceDef.SourceType\x12\x13\n\x04name\x18\x02 \x01(\tB\x05\x92?\x02\x08 \"J\n\nSourceType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x07\n\x03\x43\x41N\x10\x01\x12\x08\n\x04TIME\x10\x02\x12\x0b\n\x07VOLTAGE\x10\x03\x12\x0f\n\x0bTEMPERATURE\x10\x04\"\"\n\nInfoString\x12\x14\n\x04info\x18\x01 \x01(\tB\x06\x92?\x03\x08\x80\x01\"\xd8\x01\n\nCanMessage\x12\n\n\x02id\x18\x01 \x01(\r\x12%\n\x06length\x18\x02 \x01(\x0e\x32\x15.CanMessage.FrameType\x12 \n\x03rtr\x18\x03 \x01(\x0e\x32\x13.CanMessage.RtrType\x12\x13\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x42\x05\x92?\x02\x08\x08\"3\n\tFrameType\x12\x12\n\x0eSTANDARD_FRAME\x10\x00\x12\x12\n\x0e\x45XTENDED_FRAME\x10\x01\"+\n\x07RtrType\x12\x0e\n\nDATA_FRAME\x10\x00\x12\x10\n\x0cREMOTE_FRAME\x10\x01\"\xb4\x01\n\x08\x43\x61nError\x12%\n\x06source\x18\x01 \x01(\x0e\x32\x15.CanError.ErrorSource\"\x80\x01\n\x0b\x45rrorSource\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x11\n\rERROR_WARNING\x10\x01\x12\x11\n\rERROR_PASSIVE\x10\x02\x12\x0b\n\x07\x42US_OFF\x10\x03\x12\x10\n\x0c\x44\x41TA_OVERRUN\x10\x04\x12\x14\n\x10\x41RBITRATION_LOST\x10\x05\x12\t\n\x05OTHER\x10\x7f\"\x96\x01\n\x0f\x43\x61nErrorCounter\x12\x33\n\x06source\x18\x01 \x01(\x0e\x32#.CanErrorCounter.ErrorCounterSource\x12\r\n\x05\x63ount\x18\x02 \x01(\r\"?\n\x12\x45rrorCounterSource\x12\x14\n\x10TRANSMIT_COUNTER\x10\x00\x12\x13\n\x0fRECEIVE_COUNTER\x10\x01')
+  syntax='proto3',
+  serialized_pb=_b('\n\x10\x64\x61talogger.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x0cnanopb.proto\"]\n\x14StatisticalAggregate\x12\x0f\n\x07samples\x18\x01 \x01(\r\x12\x0b\n\x03min\x18\x02 \x01(\x05\x12\x0b\n\x03max\x18\x03 \x01(\x05\x12\x0b\n\x03\x61vg\x18\x04 \x01(\x05\x12\r\n\x05stdev\x18\x05 \x01(\r\"=\n\x0cIntHistogram\x12\x16\n\x07\x62uckets\x18\x01 \x03(\x05\x42\x05\x92?\x02\x10\n\x12\x15\n\x06\x63ounts\x18\x02 \x03(\rB\x05\x92?\x02\x10\x0b\"\x82\x01\n\x10\x44\x61taloggerRecord\x12\x14\n\x0ctimestamp_ms\x18\x01 \x01(\r\x12!\n\x15timestamp_variability\x18\x02 \x01(\rB\x02\x18\x01\x12\x10\n\x08sourceId\x18\x03 \x01(\r\x12#\n\x07payload\x18\x04 \x01(\x0b\x32\x12.DataloggerPayload\"\xa6\x04\n\x11\x44\x61taloggerPayload\x12\x1f\n\tsourceDef\x18\x01 \x01(\x0b\x32\n.SourceDefH\x00\x12\x1b\n\x04info\x18\x02 \x01(\x0b\x32\x0b.InfoStringH\x00\x12)\n\x12receivedCanMessage\x18\x03 \x01(\x0b\x32\x0b.CanMessageH\x00\x12,\n\x15transmittedCanMessage\x18\x04 \x01(\x0b\x32\x0b.CanMessageH\x00\x12\x1d\n\x08\x63\x61nError\x18\x05 \x01(\x0b\x32\t.CanErrorH\x00\x12)\n\rcanErrorCount\x18\x06 \x01(\x0b\x32\x10.CanErrorCounterH\x00\x12\x33\n\x0evoltageReading\x18\x07 \x01(\x0b\x32\x15.StatisticalAggregateB\x02\x18\x01H\x00\x12\x37\n\x12temperatureReading\x18\x08 \x01(\x0b\x32\x15.StatisticalAggregateB\x02\x18\x01H\x00\x12*\n\tloopTimer\x18\t \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x12.\n\x15loopTimerDistribution\x18\x0b \x01(\x0b\x32\r.IntHistogramH\x00\x12-\n\x07rtcTime\x18\n \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00\x12.\n\rsensorReading\x18\x0c \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x42\x07\n\x05value\"\x97\x01\n\tSourceDef\x12)\n\nsourceType\x18\x01 \x01(\x0e\x32\x15.SourceDef.SourceType\x12\x13\n\x04name\x18\x02 \x01(\tB\x05\x92?\x02\x08 \"J\n\nSourceType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x07\n\x03\x43\x41N\x10\x01\x12\x08\n\x04TIME\x10\x02\x12\x0b\n\x07VOLTAGE\x10\x03\x12\x0f\n\x0bTEMPERATURE\x10\x04\"\"\n\nInfoString\x12\x14\n\x04info\x18\x01 \x01(\tB\x06\x92?\x03\x08\x80\x01\"\xd8\x01\n\nCanMessage\x12\n\n\x02id\x18\x01 \x01(\r\x12%\n\x06length\x18\x02 \x01(\x0e\x32\x15.CanMessage.FrameType\x12 \n\x03rtr\x18\x03 \x01(\x0e\x32\x13.CanMessage.RtrType\x12\x13\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x42\x05\x92?\x02\x08\x08\"3\n\tFrameType\x12\x12\n\x0eSTANDARD_FRAME\x10\x00\x12\x12\n\x0e\x45XTENDED_FRAME\x10\x01\"+\n\x07RtrType\x12\x0e\n\nDATA_FRAME\x10\x00\x12\x10\n\x0cREMOTE_FRAME\x10\x01\"\xb4\x01\n\x08\x43\x61nError\x12%\n\x06source\x18\x01 \x01(\x0e\x32\x15.CanError.ErrorSource\"\x80\x01\n\x0b\x45rrorSource\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x11\n\rERROR_WARNING\x10\x01\x12\x11\n\rERROR_PASSIVE\x10\x02\x12\x0b\n\x07\x42US_OFF\x10\x03\x12\x10\n\x0c\x44\x41TA_OVERRUN\x10\x04\x12\x14\n\x10\x41RBITRATION_LOST\x10\x05\x12\t\n\x05OTHER\x10\x7f\"\x96\x01\n\x0f\x43\x61nErrorCounter\x12\x33\n\x06source\x18\x01 \x01(\x0e\x32#.CanErrorCounter.ErrorCounterSource\x12\r\n\x05\x63ount\x18\x02 \x01(\r\"?\n\x12\x45rrorCounterSource\x12\x14\n\x10TRANSMIT_COUNTER\x10\x00\x12\x13\n\x0fRECEIVE_COUNTER\x10\x01\x62\x06proto3')
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,nanopb__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -57,8 +57,8 @@ _SOURCEDEF_SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=928,
-  serialized_end=1002,
+  serialized_start=989,
+  serialized_end=1063,
 )
 _sym_db.RegisterEnumDescriptor(_SOURCEDEF_SOURCETYPE)
 
@@ -79,8 +79,8 @@ _CANMESSAGE_FRAMETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1161,
-  serialized_end=1212,
+  serialized_start=1222,
+  serialized_end=1273,
 )
 _sym_db.RegisterEnumDescriptor(_CANMESSAGE_FRAMETYPE)
 
@@ -101,8 +101,8 @@ _CANMESSAGE_RTRTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1214,
-  serialized_end=1257,
+  serialized_start=1275,
+  serialized_end=1318,
 )
 _sym_db.RegisterEnumDescriptor(_CANMESSAGE_RTRTYPE)
 
@@ -143,8 +143,8 @@ _CANERROR_ERRORSOURCE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1312,
-  serialized_end=1440,
+  serialized_start=1373,
+  serialized_end=1501,
 )
 _sym_db.RegisterEnumDescriptor(_CANERROR_ERRORSOURCE)
 
@@ -165,8 +165,8 @@ _CANERRORCOUNTER_ERRORCOUNTERSOURCE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1530,
-  serialized_end=1593,
+  serialized_start=1591,
+  serialized_end=1654,
 )
 _sym_db.RegisterEnumDescriptor(_CANERRORCOUNTER_ERRORCOUNTERSOURCE)
 
@@ -221,7 +221,7 @@ _STATISTICALAGGREGATE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
-  syntax='proto2',
+  syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
@@ -259,7 +259,7 @@ _INTHISTOGRAM = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
-  syntax='proto2',
+  syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
@@ -288,7 +288,7 @@ _DATALOGGERRECORD = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))),
     _descriptor.FieldDescriptor(
       name='sourceId', full_name='DataloggerRecord.sourceId', index=2,
       number=3, type=13, cpp_type=3, label=1,
@@ -311,12 +311,12 @@ _DATALOGGERRECORD = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
-  syntax='proto2',
+  syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=225,
-  serialized_end=351,
+  serialized_start=226,
+  serialized_end=356,
 )
 
 
@@ -375,14 +375,14 @@ _DATALOGGERPAYLOAD = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))),
     _descriptor.FieldDescriptor(
       name='temperatureReading', full_name='DataloggerPayload.temperatureReading', index=7,
       number=8, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))),
     _descriptor.FieldDescriptor(
       name='loopTimer', full_name='DataloggerPayload.loopTimer', index=8,
       number=9, type=11, cpp_type=10, label=1,
@@ -404,6 +404,13 @@ _DATALOGGERPAYLOAD = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='sensorReading', full_name='DataloggerPayload.sensorReading', index=11,
+      number=12, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -412,15 +419,15 @@ _DATALOGGERPAYLOAD = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
-  syntax='proto2',
+  syntax='proto3',
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
       name='value', full_name='DataloggerPayload.value',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=354,
-  serialized_end=848,
+  serialized_start=359,
+  serialized_end=909,
 )
 
 
@@ -454,12 +461,12 @@ _SOURCEDEF = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
-  syntax='proto2',
+  syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=851,
-  serialized_end=1002,
+  serialized_start=912,
+  serialized_end=1063,
 )
 
 
@@ -485,12 +492,12 @@ _INFOSTRING = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
-  syntax='proto2',
+  syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1004,
-  serialized_end=1038,
+  serialized_start=1065,
+  serialized_end=1099,
 )
 
 
@@ -539,12 +546,12 @@ _CANMESSAGE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
-  syntax='proto2',
+  syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1041,
-  serialized_end=1257,
+  serialized_start=1102,
+  serialized_end=1318,
 )
 
 
@@ -571,12 +578,12 @@ _CANERROR = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
-  syntax='proto2',
+  syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1260,
-  serialized_end=1440,
+  serialized_start=1321,
+  serialized_end=1501,
 )
 
 
@@ -610,12 +617,12 @@ _CANERRORCOUNTER = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
-  syntax='proto2',
+  syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1443,
-  serialized_end=1593,
+  serialized_start=1504,
+  serialized_end=1654,
 )
 
 _DATALOGGERRECORD.fields_by_name['payload'].message_type = _DATALOGGERPAYLOAD
@@ -630,6 +637,7 @@ _DATALOGGERPAYLOAD.fields_by_name['temperatureReading'].message_type = _STATISTI
 _DATALOGGERPAYLOAD.fields_by_name['loopTimer'].message_type = _STATISTICALAGGREGATE
 _DATALOGGERPAYLOAD.fields_by_name['loopTimerDistribution'].message_type = _INTHISTOGRAM
 _DATALOGGERPAYLOAD.fields_by_name['rtcTime'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
+_DATALOGGERPAYLOAD.fields_by_name['sensorReading'].message_type = _STATISTICALAGGREGATE
 _DATALOGGERPAYLOAD.oneofs_by_name['value'].fields.append(
   _DATALOGGERPAYLOAD.fields_by_name['sourceDef'])
 _DATALOGGERPAYLOAD.fields_by_name['sourceDef'].containing_oneof = _DATALOGGERPAYLOAD.oneofs_by_name['value']
@@ -663,6 +671,9 @@ _DATALOGGERPAYLOAD.fields_by_name['loopTimerDistribution'].containing_oneof = _D
 _DATALOGGERPAYLOAD.oneofs_by_name['value'].fields.append(
   _DATALOGGERPAYLOAD.fields_by_name['rtcTime'])
 _DATALOGGERPAYLOAD.fields_by_name['rtcTime'].containing_oneof = _DATALOGGERPAYLOAD.oneofs_by_name['value']
+_DATALOGGERPAYLOAD.oneofs_by_name['value'].fields.append(
+  _DATALOGGERPAYLOAD.fields_by_name['sensorReading'])
+_DATALOGGERPAYLOAD.fields_by_name['sensorReading'].containing_oneof = _DATALOGGERPAYLOAD.oneofs_by_name['value']
 _SOURCEDEF.fields_by_name['sourceType'].enum_type = _SOURCEDEF_SOURCETYPE
 _SOURCEDEF_SOURCETYPE.containing_type = _SOURCEDEF
 _CANMESSAGE.fields_by_name['length'].enum_type = _CANMESSAGE_FRAMETYPE
@@ -751,6 +762,12 @@ _INTHISTOGRAM.fields_by_name['buckets'].has_options = True
 _INTHISTOGRAM.fields_by_name['buckets']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\222?\002\020\n'))
 _INTHISTOGRAM.fields_by_name['counts'].has_options = True
 _INTHISTOGRAM.fields_by_name['counts']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\222?\002\020\013'))
+_DATALOGGERRECORD.fields_by_name['timestamp_variability'].has_options = True
+_DATALOGGERRECORD.fields_by_name['timestamp_variability']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
+_DATALOGGERPAYLOAD.fields_by_name['voltageReading'].has_options = True
+_DATALOGGERPAYLOAD.fields_by_name['voltageReading']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
+_DATALOGGERPAYLOAD.fields_by_name['temperatureReading'].has_options = True
+_DATALOGGERPAYLOAD.fields_by_name['temperatureReading']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
 _SOURCEDEF.fields_by_name['name'].has_options = True
 _SOURCEDEF.fields_by_name['name']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\222?\002\010 '))
 _INFOSTRING.fields_by_name['info'].has_options = True

--- a/generated/datalogger/datalogger_pb2.py
+++ b/generated/datalogger/datalogger_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='datalogger.proto',
   package='',
   syntax='proto3',
-  serialized_pb=_b('\n\x10\x64\x61talogger.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x0cnanopb.proto\"]\n\x14StatisticalAggregate\x12\x0f\n\x07samples\x18\x01 \x01(\r\x12\x0b\n\x03min\x18\x02 \x01(\x05\x12\x0b\n\x03max\x18\x03 \x01(\x05\x12\x0b\n\x03\x61vg\x18\x04 \x01(\x05\x12\r\n\x05stdev\x18\x05 \x01(\r\"=\n\x0cIntHistogram\x12\x16\n\x07\x62uckets\x18\x01 \x03(\x05\x42\x05\x92?\x02\x10\n\x12\x15\n\x06\x63ounts\x18\x02 \x03(\rB\x05\x92?\x02\x10\x0b\"~\n\x10\x44\x61taloggerRecord\x12\x14\n\x0ctimestamp_ms\x18\x01 \x01(\r\x12\x1d\n\x15timestamp_variability\x18\x02 \x01(\r\x12\x10\n\x08sourceId\x18\x03 \x01(\r\x12#\n\x07payload\x18\x04 \x01(\x0b\x32\x12.DataloggerPayload\"\xaa\x04\n\x11\x44\x61taloggerPayload\x12\x1f\n\tsourceDef\x18\x01 \x01(\x0b\x32\n.SourceDefH\x00\x12\x1b\n\x04info\x18\x02 \x01(\x0b\x32\x0b.InfoStringH\x00\x12)\n\x12receivedCanMessage\x18\x03 \x01(\x0b\x32\x0b.CanMessageH\x00\x12,\n\x15transmittedCanMessage\x18\x04 \x01(\x0b\x32\x0b.CanMessageH\x00\x12\x1d\n\x08\x63\x61nError\x18\x05 \x01(\x0b\x32\t.CanErrorH\x00\x12-\n\rcanErrorCount\x18\x06 \x01(\x0b\x32\x10.CanErrorCounterB\x02\x18\x01H\x00\x12\x33\n\x0evoltageReading\x18\x07 \x01(\x0b\x32\x15.StatisticalAggregateB\x02\x18\x01H\x00\x12\x37\n\x12temperatureReading\x18\x08 \x01(\x0b\x32\x15.StatisticalAggregateB\x02\x18\x01H\x00\x12*\n\tloopTimer\x18\t \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x12.\n\x15loopTimerDistribution\x18\x0b \x01(\x0b\x32\r.IntHistogramH\x00\x12-\n\x07rtcTime\x18\n \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00\x12.\n\rsensorReading\x18\x0c \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x42\x07\n\x05value\"\x97\x01\n\tSourceDef\x12)\n\nsourceType\x18\x01 \x01(\x0e\x32\x15.SourceDef.SourceType\x12\x13\n\x04name\x18\x02 \x01(\tB\x05\x92?\x02\x08 \"J\n\nSourceType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x07\n\x03\x43\x41N\x10\x01\x12\x08\n\x04TIME\x10\x02\x12\x0b\n\x07VOLTAGE\x10\x03\x12\x0f\n\x0bTEMPERATURE\x10\x04\"\"\n\nInfoString\x12\x14\n\x04info\x18\x01 \x01(\tB\x06\x92?\x03\x08\x80\x01\"\xd8\x01\n\nCanMessage\x12\n\n\x02id\x18\x01 \x01(\r\x12%\n\x06length\x18\x02 \x01(\x0e\x32\x15.CanMessage.FrameType\x12 \n\x03rtr\x18\x03 \x01(\x0e\x32\x13.CanMessage.RtrType\x12\x13\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x42\x05\x92?\x02\x08\x08\"3\n\tFrameType\x12\x12\n\x0eSTANDARD_FRAME\x10\x00\x12\x12\n\x0e\x45XTENDED_FRAME\x10\x01\"+\n\x07RtrType\x12\x0e\n\nDATA_FRAME\x10\x00\x12\x10\n\x0cREMOTE_FRAME\x10\x01\"\xb4\x01\n\x08\x43\x61nError\x12%\n\x06source\x18\x01 \x01(\x0e\x32\x15.CanError.ErrorSource\"\x80\x01\n\x0b\x45rrorSource\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x11\n\rERROR_WARNING\x10\x01\x12\x11\n\rERROR_PASSIVE\x10\x02\x12\x0b\n\x07\x42US_OFF\x10\x03\x12\x10\n\x0c\x44\x41TA_OVERRUN\x10\x04\x12\x14\n\x10\x41RBITRATION_LOST\x10\x05\x12\t\n\x05OTHER\x10\x7f\"\x96\x01\n\x0f\x43\x61nErrorCounter\x12\x33\n\x06source\x18\x01 \x01(\x0e\x32#.CanErrorCounter.ErrorCounterSource\x12\r\n\x05\x63ount\x18\x02 \x01(\r\"?\n\x12\x45rrorCounterSource\x12\x14\n\x10TRANSMIT_COUNTER\x10\x00\x12\x13\n\x0fRECEIVE_COUNTER\x10\x01\x62\x06proto3')
+  serialized_pb=_b('\n\x10\x64\x61talogger.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x0cnanopb.proto\"]\n\x14StatisticalAggregate\x12\x0f\n\x07samples\x18\x01 \x01(\r\x12\x0b\n\x03min\x18\x02 \x01(\x05\x12\x0b\n\x03max\x18\x03 \x01(\x05\x12\x0b\n\x03\x61vg\x18\x04 \x01(\x05\x12\r\n\x05stdev\x18\x05 \x01(\r\"=\n\x0cIntHistogram\x12\x16\n\x07\x62uckets\x18\x01 \x03(\x05\x42\x05\x92?\x02\x10\n\x12\x15\n\x06\x63ounts\x18\x02 \x03(\rB\x05\x92?\x02\x10\x0b\"~\n\x10\x44\x61taloggerRecord\x12\x14\n\x0ctimestamp_ms\x18\x01 \x01(\r\x12\x1d\n\x15timestamp_variability\x18\x02 \x01(\r\x12\x10\n\x08sourceId\x18\x03 \x01(\r\x12#\n\x07payload\x18\x04 \x01(\x0b\x32\x12.DataloggerPayload\"\xdf\x04\n\x11\x44\x61taloggerPayload\x12\x1f\n\tsourceDef\x18\x01 \x01(\x0b\x32\n.SourceDefH\x00\x12\x1b\n\x04info\x18\x02 \x01(\x0b\x32\x0b.InfoStringH\x00\x12)\n\x12receivedCanMessage\x18\x03 \x01(\x0b\x32\x0b.CanMessageH\x00\x12,\n\x15transmittedCanMessage\x18\x04 \x01(\x0b\x32\x0b.CanMessageH\x00\x12\x1d\n\x08\x63\x61nError\x18\x05 \x01(\x0b\x32\t.CanErrorH\x00\x12-\n\rcanErrorCount\x18\x06 \x01(\x0b\x32\x10.CanErrorCounterB\x02\x18\x01H\x00\x12\x33\n\x0evoltageReading\x18\x07 \x01(\x0b\x32\x15.StatisticalAggregateB\x02\x18\x01H\x00\x12\x37\n\x12temperatureReading\x18\x08 \x01(\x0b\x32\x15.StatisticalAggregateB\x02\x18\x01H\x00\x12.\n\tloopTimer\x18\t \x01(\x0b\x32\x15.StatisticalAggregateB\x02\x18\x01H\x00\x12\x32\n\x15loopTimerDistribution\x18\x0b \x01(\x0b\x32\r.IntHistogramB\x02\x18\x01H\x00\x12-\n\x07rtcTime\x18\n \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00\x12.\n\rsensorReading\x18\x0c \x01(\x0b\x32\x15.StatisticalAggregateH\x00\x12+\n\x12sensorDistribution\x18\r \x01(\x0b\x32\r.IntHistogramH\x00\x42\x07\n\x05value\"\x97\x01\n\tSourceDef\x12)\n\nsourceType\x18\x01 \x01(\x0e\x32\x15.SourceDef.SourceType\x12\x13\n\x04name\x18\x02 \x01(\tB\x05\x92?\x02\x08 \"J\n\nSourceType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x07\n\x03\x43\x41N\x10\x01\x12\x08\n\x04TIME\x10\x02\x12\x0b\n\x07VOLTAGE\x10\x03\x12\x0f\n\x0bTEMPERATURE\x10\x04\"\"\n\nInfoString\x12\x14\n\x04info\x18\x01 \x01(\tB\x06\x92?\x03\x08\x80\x01\"\xd8\x01\n\nCanMessage\x12\n\n\x02id\x18\x01 \x01(\r\x12%\n\x06length\x18\x02 \x01(\x0e\x32\x15.CanMessage.FrameType\x12 \n\x03rtr\x18\x03 \x01(\x0e\x32\x13.CanMessage.RtrType\x12\x13\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x42\x05\x92?\x02\x08\x08\"3\n\tFrameType\x12\x12\n\x0eSTANDARD_FRAME\x10\x00\x12\x12\n\x0e\x45XTENDED_FRAME\x10\x01\"+\n\x07RtrType\x12\x0e\n\nDATA_FRAME\x10\x00\x12\x10\n\x0cREMOTE_FRAME\x10\x01\"\xb4\x01\n\x08\x43\x61nError\x12%\n\x06source\x18\x01 \x01(\x0e\x32\x15.CanError.ErrorSource\"\x80\x01\n\x0b\x45rrorSource\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x11\n\rERROR_WARNING\x10\x01\x12\x11\n\rERROR_PASSIVE\x10\x02\x12\x0b\n\x07\x42US_OFF\x10\x03\x12\x10\n\x0c\x44\x41TA_OVERRUN\x10\x04\x12\x14\n\x10\x41RBITRATION_LOST\x10\x05\x12\t\n\x05OTHER\x10\x7f\"\x96\x01\n\x0f\x43\x61nErrorCounter\x12\x33\n\x06source\x18\x01 \x01(\x0e\x32#.CanErrorCounter.ErrorCounterSource\x12\r\n\x05\x63ount\x18\x02 \x01(\r\"?\n\x12\x45rrorCounterSource\x12\x14\n\x10TRANSMIT_COUNTER\x10\x00\x12\x13\n\x0fRECEIVE_COUNTER\x10\x01\x62\x06proto3')
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,nanopb__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -57,8 +57,8 @@ _SOURCEDEF_SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=988,
-  serialized_end=1062,
+  serialized_start=1041,
+  serialized_end=1115,
 )
 _sym_db.RegisterEnumDescriptor(_SOURCEDEF_SOURCETYPE)
 
@@ -79,8 +79,8 @@ _CANMESSAGE_FRAMETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1221,
-  serialized_end=1272,
+  serialized_start=1274,
+  serialized_end=1325,
 )
 _sym_db.RegisterEnumDescriptor(_CANMESSAGE_FRAMETYPE)
 
@@ -101,8 +101,8 @@ _CANMESSAGE_RTRTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1274,
-  serialized_end=1317,
+  serialized_start=1327,
+  serialized_end=1370,
 )
 _sym_db.RegisterEnumDescriptor(_CANMESSAGE_RTRTYPE)
 
@@ -143,8 +143,8 @@ _CANERROR_ERRORSOURCE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1372,
-  serialized_end=1500,
+  serialized_start=1425,
+  serialized_end=1553,
 )
 _sym_db.RegisterEnumDescriptor(_CANERROR_ERRORSOURCE)
 
@@ -165,8 +165,8 @@ _CANERRORCOUNTER_ERRORCOUNTERSOURCE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1590,
-  serialized_end=1653,
+  serialized_start=1643,
+  serialized_end=1706,
 )
 _sym_db.RegisterEnumDescriptor(_CANERRORCOUNTER_ERRORCOUNTERSOURCE)
 
@@ -389,14 +389,14 @@ _DATALOGGERPAYLOAD = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))),
     _descriptor.FieldDescriptor(
       name='loopTimerDistribution', full_name='DataloggerPayload.loopTimerDistribution', index=9,
       number=11, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))),
     _descriptor.FieldDescriptor(
       name='rtcTime', full_name='DataloggerPayload.rtcTime', index=10,
       number=10, type=11, cpp_type=10, label=1,
@@ -407,6 +407,13 @@ _DATALOGGERPAYLOAD = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='sensorReading', full_name='DataloggerPayload.sensorReading', index=11,
       number=12, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='sensorDistribution', full_name='DataloggerPayload.sensorDistribution', index=12,
+      number=13, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -427,7 +434,7 @@ _DATALOGGERPAYLOAD = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=354,
-  serialized_end=908,
+  serialized_end=961,
 )
 
 
@@ -465,8 +472,8 @@ _SOURCEDEF = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=911,
-  serialized_end=1062,
+  serialized_start=964,
+  serialized_end=1115,
 )
 
 
@@ -496,8 +503,8 @@ _INFOSTRING = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1064,
-  serialized_end=1098,
+  serialized_start=1117,
+  serialized_end=1151,
 )
 
 
@@ -550,8 +557,8 @@ _CANMESSAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1101,
-  serialized_end=1317,
+  serialized_start=1154,
+  serialized_end=1370,
 )
 
 
@@ -582,8 +589,8 @@ _CANERROR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1320,
-  serialized_end=1500,
+  serialized_start=1373,
+  serialized_end=1553,
 )
 
 
@@ -621,8 +628,8 @@ _CANERRORCOUNTER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1503,
-  serialized_end=1653,
+  serialized_start=1556,
+  serialized_end=1706,
 )
 
 _DATALOGGERRECORD.fields_by_name['payload'].message_type = _DATALOGGERPAYLOAD
@@ -638,6 +645,7 @@ _DATALOGGERPAYLOAD.fields_by_name['loopTimer'].message_type = _STATISTICALAGGREG
 _DATALOGGERPAYLOAD.fields_by_name['loopTimerDistribution'].message_type = _INTHISTOGRAM
 _DATALOGGERPAYLOAD.fields_by_name['rtcTime'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
 _DATALOGGERPAYLOAD.fields_by_name['sensorReading'].message_type = _STATISTICALAGGREGATE
+_DATALOGGERPAYLOAD.fields_by_name['sensorDistribution'].message_type = _INTHISTOGRAM
 _DATALOGGERPAYLOAD.oneofs_by_name['value'].fields.append(
   _DATALOGGERPAYLOAD.fields_by_name['sourceDef'])
 _DATALOGGERPAYLOAD.fields_by_name['sourceDef'].containing_oneof = _DATALOGGERPAYLOAD.oneofs_by_name['value']
@@ -674,6 +682,9 @@ _DATALOGGERPAYLOAD.fields_by_name['rtcTime'].containing_oneof = _DATALOGGERPAYLO
 _DATALOGGERPAYLOAD.oneofs_by_name['value'].fields.append(
   _DATALOGGERPAYLOAD.fields_by_name['sensorReading'])
 _DATALOGGERPAYLOAD.fields_by_name['sensorReading'].containing_oneof = _DATALOGGERPAYLOAD.oneofs_by_name['value']
+_DATALOGGERPAYLOAD.oneofs_by_name['value'].fields.append(
+  _DATALOGGERPAYLOAD.fields_by_name['sensorDistribution'])
+_DATALOGGERPAYLOAD.fields_by_name['sensorDistribution'].containing_oneof = _DATALOGGERPAYLOAD.oneofs_by_name['value']
 _SOURCEDEF.fields_by_name['sourceType'].enum_type = _SOURCEDEF_SOURCETYPE
 _SOURCEDEF_SOURCETYPE.containing_type = _SOURCEDEF
 _CANMESSAGE.fields_by_name['length'].enum_type = _CANMESSAGE_FRAMETYPE
@@ -768,6 +779,10 @@ _DATALOGGERPAYLOAD.fields_by_name['voltageReading'].has_options = True
 _DATALOGGERPAYLOAD.fields_by_name['voltageReading']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
 _DATALOGGERPAYLOAD.fields_by_name['temperatureReading'].has_options = True
 _DATALOGGERPAYLOAD.fields_by_name['temperatureReading']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
+_DATALOGGERPAYLOAD.fields_by_name['loopTimer'].has_options = True
+_DATALOGGERPAYLOAD.fields_by_name['loopTimer']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
+_DATALOGGERPAYLOAD.fields_by_name['loopTimerDistribution'].has_options = True
+_DATALOGGERPAYLOAD.fields_by_name['loopTimerDistribution']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\030\001'))
 _SOURCEDEF.fields_by_name['name'].has_options = True
 _SOURCEDEF.fields_by_name['name']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\222?\002\010 '))
 _INFOSTRING.fields_by_name['info'].has_options = True


### PR DESCRIPTION
Deprecate temperature, voltage, and loop timer payload types in favor of unified sensorReading,